### PR TITLE
Click a cell logics

### DIFF
--- a/minesweeper.c
+++ b/minesweeper.c
@@ -225,9 +225,16 @@ class FieldManager {
 			itr->second = updatedCell;
 		}
 
+		void revealCell(int l, int c){
+			Cell cell = getCellByCoordinates(l, c);
+			cell.reveal();
+			revealedCells++;
+			updateCell(cell, l, c);
+		}
+
 		int chooseCell(int l, int c){
 			int output;
-			Cell cell = getCellByCoordinates(l, c)
+			Cell cell = getCellByCoordinates(l, c);
 			if cell.alreadyRevealed(){
 				cout << "This cell have been already revealed! Choice other cell!"
 			}
@@ -262,10 +269,8 @@ class FieldManager {
 				else {
 
 					//Show only this cell!
-					cell.reveal();
-					revealedCells++;
-					updateCell(cell, l, c);
-					
+					revealCell(l, c);
+
 					if (cell.getBombsInNeighborhood() == 0){
 						//if this cell hasn't a number, we need to check if
 						//there are more cells to reveal! it will be did by the method
@@ -289,6 +294,7 @@ class FieldManager {
 			Queue queue = Queue();
 
 			do {
+
 
 			} while ();
 		}

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -222,6 +222,27 @@ class FieldManager {
 			itr->second = updatedCell;
 		}
 
+		void chooseCell(int l, int c){
+			Cell cell = getCellByCoordinates(l, c)
+			if cell.alreadyRevealed(){
+				cout << "This cell have been already revealed! Choice other cell!"
+			}
+			else {
+				if (cell.getIsBomb()){
+					//show all bombs!
+					//game over!
+				}
+
+				else if (cell.getBombsInNeighborhood() > 0){
+					//Show only this cell!
+				}
+
+				else{
+					//Show a group of cells!
+				}
+			}
+		}
+
 
 	private:
 		int lines;

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -208,7 +208,7 @@ class FieldManager {
 				}
 				cout << endl;
             }
-			
+			cout << endl;
 		}
 
 		Cell getCellByCoordinates(int line, int column){

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -198,11 +198,11 @@ class FieldManager {
 			for (int i = 1; i <= lines; i++){
 				for (int j = 1; j <= columns; j++){
 					Cell auxiliaryCell = getCellByCoordinates(i,j);
-					if (auxiliaryCell.getIsBomb()){
-						cout << "B ";
+					if (auxiliaryCell.alreadyRevealed()){
+						cout << auxiliaryCell.getBombsInNeighborhood() << " ";
 					}
 					else {
-						cout << auxiliaryCell.getBombsInNeighborhood() << " ";
+						cout << "# ";
 					}  
 					
 				}
@@ -278,6 +278,7 @@ class FieldManager {
 						revealGroupOfCells(l, c);
 					}
 
+					printField();
 					//output == 1 -> still playing
 					//output == 2 -> user won!
 					if (didUserWin()) {
@@ -310,62 +311,119 @@ class FieldManager {
 		}
 
 
-		void revealGroupOfCells(int l, int c){
+		void revealGroupOfCells(int starter_l, int starter_c){
+			//This method traverse the field map to select the cells which will be showed
+			//Its use an
 			Queue queue = Queue();
-			string key = toStr(l) + "-" + toStr(c);
-			queue.enqueue(key)
+			string key = toStr(starter_l) + "-" + toStr(starter_c);
+			vector<int> coordinates;
+			queue.enqueue(key);
+			int l;
+			int c;
 
 			while (!queue.isEmpty()) {
+				
+				key = queue.dequeue();
+				coordinates = split(key);
+				l = coordinates[0];
+				c = coordinates[1];
 
 				Cell currentCell = getCellByCoordinates(l,c);
 				if (!currentCell.alreadyRevealed()){
 					//If the cell has not been revealed, reveal it!
-
-
+					revealCell(l, c);
 				}
 
-
 				//Check l-1 / c-1
+				//If it is a 0/empty cell we add it the queue to ve analysed about its neighbor at next iteration
+				//else, we just reveal it
 				if (l-1 >= 1 && c-1 >= 1) {
-					incrementSingleNeighborCell(l-1, c-1);
+					Cell auxiliaryCell = getCellByCoordinates(l-1, c-1);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l-1) + "-" + toStr(c-1));
+					}
+					else{
+						revealCell(l-1, c-1);
+					}
+
 				}
 
 				//Check l-1 / c
 				if (l-1 >= 1) {
-					incrementSingleNeighborCell(l-1, c);
+					Cell auxiliaryCell = getCellByCoordinates(l-1, c);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l-1) + "-" + toStr(c));
+					}
+					else{
+						revealCell(l-1, c);
+					}
 				}
 
 				//Check l-1 / c + 1
 				if (l-1 >= 1 && c+1 <= columns) {
-					incrementSingleNeighborCell(l-1, c+1);
+					Cell auxiliaryCell = getCellByCoordinates(l-1, c+1);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l-1) + "-" + toStr(c+1));
+					}
+					else{
+						revealCell(l-1, c+1);
+					}
 				}
 
 				//Check l / c - 1
 				if (c-1 >= 1) {
-					incrementSingleNeighborCell(l, c-1);
+					Cell auxiliaryCell = getCellByCoordinates(l, c-1);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l) + "-" + toStr(c-1));
+					}
+					else{
+						revealCell(l, c-1);
+					}
 				}
 
 				//Check l / c + 1
 				if (c+1 <= columns) {
-					incrementSingleNeighborCell(l, c+1);
+					Cell auxiliaryCell = getCellByCoordinates(l, c+1);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l) + "-" + toStr(c+1));
+					}
+					else{
+						revealCell(l, c+1);
+					}
 				}
 
 				//Check l+1 / c - 1
 				if (l+1 <= lines && c-1 >= 1) {
-					incrementSingleNeighborCell(l+1, c-1);
+					Cell auxiliaryCell = getCellByCoordinates(l+1, c-1);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l+1) + "-" + toStr(c-1));
+					}
+					else{
+						revealCell(l+1, c-1);
+					}
 				}
 
 				//Check l+1 / c
 				if (l+1 <= lines) {
-					incrementSingleNeighborCell(l+1, c);
+					Cell auxiliaryCell = getCellByCoordinates(l+1, c);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l+1) + "-" + toStr(c));
+					}
+					else{
+						revealCell(l+1, c);
+					}
 				}
 
 				//Check l+1 / c+1
 				if (l+1 <= lines && c+1 <= columns) {
-					incrementSingleNeighborCell(l+1, c+1);
+					Cell auxiliaryCell = getCellByCoordinates(l+1, c+1);
+					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+						queue.enqueue(toStr(l+1) + "-" + toStr(c+1));
+					}
+					else{
+						revealCell(l+1, c+1);
+					}
 				}
-
-
 			} 
 		}
 

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -235,8 +235,8 @@ class FieldManager {
 		int chooseCell(int l, int c){
 			int output;
 			Cell cell = getCellByCoordinates(l, c);
-			if cell.alreadyRevealed(){
-				cout << "This cell have been already revealed! Choice other cell!"
+			if (cell.alreadyRevealed()){
+				cout << "This cell have been already revealed! Choice other cell!";
 			}
 			else {
 				if (cell.getIsBomb()){
@@ -289,19 +289,20 @@ class FieldManager {
 					}
 
 				}
+			}
 		}
 
 		vector<int> split(string str){
-			vector<string> output;
+			vector<int> output;
 			string buffer = "";
 			int i = 0;
 			int number;
-			while i < (str.length()){
+			while (i < str.length()){
 				if (str[i] != "-"){
 					buffer += str[i];
 				}
 				else{
-					number = stoi(buffer)
+					number = std::stoi(buffer)
 					output.push_back(number);
 					buffer = "";
 				}
@@ -429,7 +430,7 @@ class FieldManager {
 
 
 		bool didUserWin(){
-			return revealedCells + numberOfBombs == lines * columns
+			return revealedCells + numberOfBombs == lines * columns;
 		}
 
 

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -233,6 +233,26 @@ class FieldManager {
 				if (cell.getIsBomb()){
 					//show all bombs!
 					//game over!
+					for (int i = 1; i <= lines; i++){
+						for (int j = 1; j <= columns; j++){
+							Cell auxiliaryCell = getCellByCoordinates(i,j);
+							//If the cell is a bomb, show it!
+							if (auxiliaryCell.getIsBomb()){
+								cout << "B ";
+							}
+							else {
+								//If the cell has been revealed, show its value.
+								if (auxiliaryCell.alreadyRevealed()){
+									cout << auxiliaryCell.getBombsInNeighborhood() << " ";
+								}
+								else{
+									//Else, stay it hidden, as the game does
+									cout << "# ";
+								}
+							}
+						}
+						cout << endl;
+           	 		}
 				}
 
 				else if (cell.getBombsInNeighborhood() > 0){

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -292,6 +292,13 @@ class FieldManager {
 			}
 		}
 
+		int toInt(string str){
+			stringstream auxiliary(str); 
+			int output; 
+    		auxiliary >> output;
+			return output; 
+		}
+
 		vector<int> split(string str){
 			vector<int> output;
 			string buffer = "";
@@ -302,12 +309,16 @@ class FieldManager {
 					buffer += str[i];
 				}
 				else{
-					number = std::stoi(buffer)
+					number = toInt(buffer);
 					output.push_back(number);
 					buffer = "";
 				}
 				i++;
 			}
+			//add the last buffer to the outpu. 
+			//Because the loop exits before did it
+			number = toInt(buffer);
+			output.push_back(number);
 			return output;
 		}
 
@@ -448,7 +459,8 @@ class FieldManager {
 int main() 
 {
 	FieldManager teste = FieldManager(15, 15, 20);
-	teste.split("12-12");
+	vector<int> t1 = teste.split("12-12");
+	//cout << t1[0] << endl << t1[1];
 	//teste.initializeField();
 	//teste.printField();
 	//Cell t1 = Cell(false);

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -94,7 +94,7 @@ class FieldManager {
 		void initializeField(){
 			//Fill the field with cell instances
 			string key;
-			map<int, bool>::iterator iter;
+			map<int, string>::iterator iter;
 			//The position counter will know when the specified position is a bomb position.
 			//It reach this objective checking on the bombPositions map.
 			int positionCounter = 1;
@@ -105,6 +105,8 @@ class FieldManager {
 					//If the current position is a bomb position, we will create the cell as bomb
 					if (iter != bombsPositions.end()){
 						field.insert(pair<string, Cell>(key, Cell(true)));
+						//Save its position at the bombPositions map
+						iter->second = key;
 					}
 					else {
 						field.insert(pair<string, Cell>(key, Cell(false)));
@@ -126,7 +128,7 @@ class FieldManager {
 
 		void generateBombPositions(){
 			int randomNumber;
-			map<int, bool>::iterator iter;
+			map<int, string>::iterator iter;
 			int i = 1;
 			while(i <= numberOfBombs){
 				randomNumber = rand() % (lines*columns) + 1;
@@ -135,7 +137,7 @@ class FieldManager {
 				//If these number already exists on the map, we need to generate
 				// other random number for a bomb position
 				if (iter == bombsPositions.end()){
-					bombsPositions.insert(pair<int, bool>(randomNumber, true)); 
+					bombsPositions.insert(pair<int, string>(randomNumber, " ")); 
 					i++;
 				}
 			}
@@ -249,7 +251,7 @@ class FieldManager {
 		int columns;
 		int numberOfBombs;
 		map<string, Cell> field;
-		map<int, bool> bombsPositions;
+		map<int, string> bombsPositions;
 
 };
 

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -259,12 +259,19 @@ class FieldManager {
 					output = 0;
 				}
 
-				else if (cell.getBombsInNeighborhood() > 0){
+				else {
+
 					//Show only this cell!
 					cell.reveal();
 					revealedCells++;
-
 					updateCell(cell, l, c);
+					
+					if (cell.getBombsInNeighborhood() == 0){
+						//if this cell hasn't a number, we need to check if
+						//there are more cells to reveal! it will be did by the method
+						//revealgroupofCells
+					}
+
 					//output == 1 -> still playing
 					//output == 2 -> user won!
 					if (didUserWin()) {
@@ -273,13 +280,14 @@ class FieldManager {
 					else {
 						output = 1;
 					}
-				}
 
-				else{
-					//Show a group of cells!
 				}
-			}
 		}
+
+		void revealGroupOfCells(int l, int c){
+
+		}
+
 
 		bool didUserWin(){
 			return revealedCells + numberOfBombs == lines * columns

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -290,13 +290,81 @@ class FieldManager {
 				}
 		}
 
+		vector<string> split(string str){
+			vector<string> output;
+			string buffer = "";
+			int i = 0;
+			while i < (str.length()){
+				if (str[i] != "-"){
+					buffer += str[i];
+				}
+				else{
+					output.push_back(buffer);
+					buffer = "";
+				}
+				i++;
+			}
+			return output;
+		}
+
+
 		void revealGroupOfCells(int l, int c){
 			Queue queue = Queue();
+			string key = toStr(l) + "-" + toStr(c);
+			queue.enqueue(key)
 
-			do {
+			while (!queue.isEmpty()) {
+
+				Cell currentCell = getCellByCoordinates(l,c);
+				if (!currentCell.alreadyRevealed()){
+					//If the cell has not been revealed, reveal it!
 
 
-			} while ();
+				}
+
+
+				//Check l-1 / c-1
+				if (l-1 >= 1 && c-1 >= 1) {
+					incrementSingleNeighborCell(l-1, c-1);
+				}
+
+				//Check l-1 / c
+				if (l-1 >= 1) {
+					incrementSingleNeighborCell(l-1, c);
+				}
+
+				//Check l-1 / c + 1
+				if (l-1 >= 1 && c+1 <= columns) {
+					incrementSingleNeighborCell(l-1, c+1);
+				}
+
+				//Check l / c - 1
+				if (c-1 >= 1) {
+					incrementSingleNeighborCell(l, c-1);
+				}
+
+				//Check l / c + 1
+				if (c+1 <= columns) {
+					incrementSingleNeighborCell(l, c+1);
+				}
+
+				//Check l+1 / c - 1
+				if (l+1 <= lines && c-1 >= 1) {
+					incrementSingleNeighborCell(l+1, c-1);
+				}
+
+				//Check l+1 / c
+				if (l+1 <= lines) {
+					incrementSingleNeighborCell(l+1, c);
+				}
+
+				//Check l+1 / c+1
+				if (l+1 <= lines && c+1 <= columns) {
+					incrementSingleNeighborCell(l+1, c+1);
+				}
+
+
+			} 
 		}
 
 

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -80,6 +80,7 @@ class FieldManager {
 			lines = l;
 			columns = c;
 			numberOfBombs = n;
+			revealedCells = 0;
 			generateBombPositions();
 
 		}
@@ -224,7 +225,8 @@ class FieldManager {
 			itr->second = updatedCell;
 		}
 
-		void chooseCell(int l, int c){
+		int chooseCell(int l, int c){
+			int output;
 			Cell cell = getCellByCoordinates(l, c)
 			if cell.alreadyRevealed(){
 				cout << "This cell have been already revealed! Choice other cell!"
@@ -253,6 +255,8 @@ class FieldManager {
 						}
 						cout << endl;
            	 		}
+					//output == 0 -> game over!	
+					output = 0;
 				}
 
 				else if (cell.getBombsInNeighborhood() > 0){
@@ -270,6 +274,7 @@ class FieldManager {
 		int lines;
 		int columns;
 		int numberOfBombs;
+		int revealedCells;
 		map<string, Cell> field;
 		map<int, string> bombsPositions;
 

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -236,7 +236,7 @@ class FieldManager {
 			int output;
 			Cell cell = getCellByCoordinates(l, c);
 			if (cell.alreadyRevealed()){
-				cout << "This cell have been already revealed! Choice other cell!";
+				cout << "This cell have been already revealed! Choice other cell!" << endl;
 			}
 			else {
 				if (cell.getIsBomb()){
@@ -334,7 +334,6 @@ class FieldManager {
 			int c;
 
 			while (!queue.isEmpty()) {
-				
 				key = queue.dequeue();
 				coordinates = split(key);
 				l = coordinates[0];
@@ -351,7 +350,7 @@ class FieldManager {
 				//else, we just reveal it
 				if (l-1 >= 1 && c-1 >= 1) {
 					Cell auxiliaryCell = getCellByCoordinates(l-1, c-1);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l-1) + "-" + toStr(c-1));
 					}
 					else{
@@ -363,7 +362,7 @@ class FieldManager {
 				//Check l-1 / c
 				if (l-1 >= 1) {
 					Cell auxiliaryCell = getCellByCoordinates(l-1, c);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l-1) + "-" + toStr(c));
 					}
 					else{
@@ -374,7 +373,7 @@ class FieldManager {
 				//Check l-1 / c + 1
 				if (l-1 >= 1 && c+1 <= columns) {
 					Cell auxiliaryCell = getCellByCoordinates(l-1, c+1);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l-1) + "-" + toStr(c+1));
 					}
 					else{
@@ -385,7 +384,7 @@ class FieldManager {
 				//Check l / c - 1
 				if (c-1 >= 1) {
 					Cell auxiliaryCell = getCellByCoordinates(l, c-1);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l) + "-" + toStr(c-1));
 					}
 					else{
@@ -396,7 +395,7 @@ class FieldManager {
 				//Check l / c + 1
 				if (c+1 <= columns) {
 					Cell auxiliaryCell = getCellByCoordinates(l, c+1);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l) + "-" + toStr(c+1));
 					}
 					else{
@@ -407,7 +406,7 @@ class FieldManager {
 				//Check l+1 / c - 1
 				if (l+1 <= lines && c-1 >= 1) {
 					Cell auxiliaryCell = getCellByCoordinates(l+1, c-1);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l+1) + "-" + toStr(c-1));
 					}
 					else{
@@ -418,7 +417,7 @@ class FieldManager {
 				//Check l+1 / c
 				if (l+1 <= lines) {
 					Cell auxiliaryCell = getCellByCoordinates(l+1, c);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l+1) + "-" + toStr(c));
 					}
 					else{
@@ -429,7 +428,7 @@ class FieldManager {
 				//Check l+1 / c+1
 				if (l+1 <= lines && c+1 <= columns) {
 					Cell auxiliaryCell = getCellByCoordinates(l+1, c+1);
-					if (auxiliaryCell.getBombsInNeighborhood() == 0){
+					if (auxiliaryCell.getBombsInNeighborhood() == 0 && !auxiliaryCell.alreadyRevealed()){
 						queue.enqueue(toStr(l+1) + "-" + toStr(c+1));
 					}
 					else{
@@ -459,10 +458,15 @@ class FieldManager {
 int main() 
 {
 	FieldManager teste = FieldManager(15, 15, 20);
-	vector<int> t1 = teste.split("12-12");
-	//cout << t1[0] << endl << t1[1];
-	//teste.initializeField();
+	teste.initializeField();
+	teste.chooseCell(1,1);
+	teste.chooseCell(1,1);
+	teste.chooseCell(1,2);
+	teste.chooseCell(1,3);
+
+	
 	//teste.printField();
+	
 	//Cell t1 = Cell(false);
 	//map<int, Cell> teste; 
 	//map<int, Cell>::iterator itr;

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -261,12 +261,28 @@ class FieldManager {
 
 				else if (cell.getBombsInNeighborhood() > 0){
 					//Show only this cell!
+					cell.reveal();
+					revealedCells++;
+
+					updateCell(cell, l, c);
+					//output == 1 -> still playing
+					//output == 2 -> user won!
+					if (didUserWin()) {
+						output = 2;
+					}
+					else {
+						output = 1;
+					}
 				}
 
 				else{
 					//Show a group of cells!
 				}
 			}
+		}
+
+		bool didUserWin(){
+			return revealedCells + numberOfBombs == lines * columns
 		}
 
 

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -290,16 +290,18 @@ class FieldManager {
 				}
 		}
 
-		vector<string> split(string str){
+		vector<int> split(string str){
 			vector<string> output;
 			string buffer = "";
 			int i = 0;
+			int number;
 			while i < (str.length()){
 				if (str[i] != "-"){
 					buffer += str[i];
 				}
 				else{
-					output.push_back(buffer);
+					number = stoi(buffer)
+					output.push_back(number);
 					buffer = "";
 				}
 				i++;

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -7,7 +7,14 @@
 #include "stdlib.h"
 
 
+
+
 using namespace std; 
+
+#define RESET   "\033[0m"
+#define RED     "\033[31m" 
+#define BLUE    "\033[34m"
+#define WHITE   "\033[37m"
 
 class Queue {
 	public:
@@ -199,7 +206,12 @@ class FieldManager {
 				for (int j = 1; j <= columns; j++){
 					Cell auxiliaryCell = getCellByCoordinates(i,j);
 					if (auxiliaryCell.alreadyRevealed()){
-						cout << auxiliaryCell.getBombsInNeighborhood() << " ";
+						if (auxiliaryCell.getBombsInNeighborhood() > 0){
+							cout << BLUE << auxiliaryCell.getBombsInNeighborhood() << " " << RESET;
+						}
+						else {
+							cout << WHITE << auxiliaryCell.getBombsInNeighborhood() << " " << RESET;
+						}
 					}
 					else {
 						cout << "# ";
@@ -247,12 +259,17 @@ class FieldManager {
 							Cell auxiliaryCell = getCellByCoordinates(i,j);
 							//If the cell is a bomb, show it!
 							if (auxiliaryCell.getIsBomb()){
-								cout << "B ";
+								cout << RED << "B " << RESET;
 							}
 							else {
 								//If the cell has been revealed, show its value.
 								if (auxiliaryCell.alreadyRevealed()){
-									cout << auxiliaryCell.getBombsInNeighborhood() << " ";
+									if (auxiliaryCell.getBombsInNeighborhood() > 0){
+										cout << BLUE << auxiliaryCell.getBombsInNeighborhood() << " " << RESET;
+									}
+									else {
+										cout << WHITE << auxiliaryCell.getBombsInNeighborhood() << " " << RESET;
+									}
 								}
 								else{
 									//Else, stay it hidden, as the game does
@@ -463,6 +480,10 @@ int main()
 	teste.chooseCell(1,1);
 	teste.chooseCell(1,2);
 	teste.chooseCell(1,3);
+	//teste.chooseCell(15,3);
+	teste.chooseCell(5,15);
+	teste.chooseCell(2,12);
+	teste.chooseCell(3,5);
 
 	
 	//teste.printField();

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -298,7 +298,7 @@ class FieldManager {
 			int i = 0;
 			int number;
 			while (i < str.length()){
-				if (str[i] != "-"){
+				if (str[i] != '-'){
 					buffer += str[i];
 				}
 				else{
@@ -448,8 +448,9 @@ class FieldManager {
 int main() 
 {
 	FieldManager teste = FieldManager(15, 15, 20);
-	teste.initializeField();
-	teste.printField();
+	teste.split("12-12");
+	//teste.initializeField();
+	//teste.printField();
 	//Cell t1 = Cell(false);
 	//map<int, Cell> teste; 
 	//map<int, Cell>::iterator itr;

--- a/minesweeper.c
+++ b/minesweeper.c
@@ -270,6 +270,7 @@ class FieldManager {
 						//if this cell hasn't a number, we need to check if
 						//there are more cells to reveal! it will be did by the method
 						//revealgroupofCells
+						revealGroupOfCells(l, c);
 					}
 
 					//output == 1 -> still playing
@@ -285,7 +286,11 @@ class FieldManager {
 		}
 
 		void revealGroupOfCells(int l, int c){
+			Queue queue = Queue();
 
+			do {
+
+			} while ();
 		}
 
 


### PR DESCRIPTION
Implemented the logics necessary to click a cell.
The implemented methods were:
- chooseCell. It will process the cell selected by the user. Check if it is a bomb, a cell without bombs next (0 numered) or a cell with bombs next (0<) cells. If it is the first case, the game ends and all bombs are showed. If is the third case, it only shows the selected cell (with its number). If is the second case, we will need a BFS to know which cells will be showed. This logic is done by the method revealGroupOfCells.
- revealGroupOfCells. It does and BFS around 0 numered cells to know what will be showed after clicking in on of them.
- didUserWin. Based on the number of revealed cells, will say if the user won the game.
- RevealCell. Auxiliary method which reveal a cell and update its state on the field map
- toInt. It does a cast simple operation
- Split. Breaks a key of the map into 2 ints

Did some minor modifications, described in the commits. Added different colors to visualize the difference between bombs, numered and 0 numered cells.